### PR TITLE
rule(jest): error --> "jest/no-disabled-tests"

### DIFF
--- a/packages/eslint-config-sentry-react/rules/jest.js
+++ b/packages/eslint-config-sentry-react/rules/jest.js
@@ -5,6 +5,6 @@
 module.exports = {
   rules: {
     'jest/no-large-snapshots': ['warn', {maxSize: 2000}],
-    'jest/no-disabled-tests': 'warn',
+    'jest/no-disabled-tests': 'error',
   },
 };


### PR DESCRIPTION
Disabled tests should error, if you want to keep them in, you must consciously disable the rule with inline comments. Otherwise it's too easy to commit disabled tests when you're just developing.