### PR TITLE
feat(babel7): Enable legacyDecorators for babel 7

### DIFF
--- a/packages/eslint-config-sentry-app/index.js
+++ b/packages/eslint-config-sentry-app/index.js
@@ -15,6 +15,7 @@ module.exports = {
     ecmaFeatures: {
       jsx: true,
       modules: true,
+      legacyDecorators: true,
     },
   },
 


### PR DESCRIPTION
When we bump `babel-eslint` for babel 7 we will need this configuration via https://github.com/babel/babel-eslint/releases/tag/v9.0.0