### PR TITLE
feat(rule): Add current warnings as errors in strict ruleset

### DIFF
--- a/packages/eslint-config-sentry-app-strict/index.js
+++ b/packages/eslint-config-sentry-app-strict/index.js
@@ -1,4 +1,3 @@
-// Default: sentry app
 module.exports = {
   extends: [
     'sentry-app'
@@ -7,5 +6,18 @@ module.exports = {
   rules: {
     "no-console": ['error'],
     "no-debugger": ['error'],
+
+    // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-is-mounted.md
+    'react/no-is-mounted': ['error'],
+
+    // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-find-dom-node.md
+    // Recommended to use callback refs instead
+    'react/no-find-dom-node': ['error'],
+
+    // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-string-refs.md
+    // This is now considered legacy, callback refs preferred
+    'react/no-string-refs': ['error'],
+
+    'jest/no-large-snapshots': ['error', {maxSize: 2000}],
   },
 };


### PR DESCRIPTION
These rules are currently warnings in `eslint-config-sentry-app`, let's add them to the strict ruleset as errors so that we can try to catch these during pre commit hooks.