### PR TITLE
RFC- feat(curly) Enable curly

### DIFF
--- a/packages/eslint-config-sentry-app/index.js
+++ b/packages/eslint-config-sentry-app/index.js
@@ -1,11 +1,11 @@
 // Default: sentry app
 module.exports = {
   extends: [
-    'sentry-react',
     'prettier',
     'plugin:prettier/recommended',
     'prettier/react',
     'prettier/standard',
+    'sentry-react',
   ],
 
   parser: 'babel-eslint',

--- a/packages/eslint-config-sentry/rules/base.js
+++ b/packages/eslint-config-sentry/rules/base.js
@@ -111,7 +111,7 @@ module.exports = {
     'consistent-return': ['error'],
 
     // http://eslint.org/docs/rules/curly
-    curly: ['all'],
+    curly: ['error', 'all'],
 
     // http://eslint.org/docs/rules/default-case
     'default-case': ['error'],

--- a/packages/eslint-config-sentry/rules/base.js
+++ b/packages/eslint-config-sentry/rules/base.js
@@ -110,8 +110,8 @@ module.exports = {
     // http://eslint.org/docs/rules/consistent-return
     'consistent-return': ['error'],
 
-    // http://eslint.org/docs/rules/curly [REVISIT ME]
-    curly: ['off'],
+    // http://eslint.org/docs/rules/curly
+    curly: ['all'],
 
     // http://eslint.org/docs/rules/default-case
     'default-case': ['error'],


### PR DESCRIPTION
We are reasonably inconsistent with our usage of braces. This can complicate refactoring as moving lines around can break behavior for if statements and if/else pairs. By always requiring braces we can avoid these issues and have clearer code.

If folks agree with this, I'll update sentry and getsentry to have more braces.