### PR TITLE
feat(rule): Change no-unused-vars to ignore underscores and unused positional args

### DIFF
--- a/packages/eslint-config-sentry/rules/base.js
+++ b/packages/eslint-config-sentry/rules/base.js
@@ -28,7 +28,18 @@ module.exports = {
       'error',
       {
         vars: 'local',
-        args: 'none',
+
+        // unused positional arguments that occur before the last used argument will not be checked,
+        // but all named arguments and all positional arguments after the last used argument will be checked.
+        args: 'after-used',
+
+        // Ignore vars that start with an underscore
+        // e.g. if you want to omit a property using object spread:
+        //
+        //   const {name: _name, ...props} = this.props;
+        //
+        varsIgnorePattern: '^_',
+        argsIgnorePattern: '^_',
       },
     ],
 


### PR DESCRIPTION
When checking for unused vars/args, ignore them when they begin with an underscore (`_`).
Also allow unused positional args that occur before the last used argument.