### PR TITLE
feat(rule): Only check for unused args in strict ruleset

### DIFF
--- a/packages/eslint-config-sentry-app-strict/index.js
+++ b/packages/eslint-config-sentry-app-strict/index.js
@@ -1,11 +1,27 @@
 module.exports = {
-  extends: [
-    'sentry-app'
-  ],
+  extends: ['sentry-app'],
 
   rules: {
-    "no-console": ['error'],
-    "no-debugger": ['error'],
+    'no-console': ['error'],
+    'no-debugger': ['error'],
+
+    // This only override the `args` rule (which is "none"). There are too many errors and it's difficult to manually
+    // fix them all, so we'll have to incrementally update.
+    'no-unused-vars': [
+      'error',
+      {
+        vars: 'local',
+        args: 'all',
+
+        // Ignore vars that start with an underscore
+        // e.g. if you want to omit a property using object spread:
+        //
+        //   const {name: _name, ...props} = this.props;
+        //
+        varsIgnorePattern: '^_',
+        argsIgnorePattern: '^_',
+      },
+    ],
 
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/no-is-mounted.md
     'react/no-is-mounted': ['error'],

--- a/packages/eslint-config-sentry-app-strict/index.js
+++ b/packages/eslint-config-sentry-app-strict/index.js
@@ -10,7 +10,7 @@ module.exports = {
     'no-unused-vars': [
       'error',
       {
-        vars: 'local',
+        vars: 'all',
         args: 'all',
 
         // Ignore vars that start with an underscore

--- a/packages/eslint-config-sentry/rules/base.js
+++ b/packages/eslint-config-sentry/rules/base.js
@@ -27,7 +27,7 @@ module.exports = {
     'no-unused-vars': [
       'error',
       {
-        vars: 'local',
+        vars: 'all',
         args: 'none',
 
         // Ignore vars that start with an underscore

--- a/packages/eslint-config-sentry/rules/base.js
+++ b/packages/eslint-config-sentry/rules/base.js
@@ -28,10 +28,7 @@ module.exports = {
       'error',
       {
         vars: 'local',
-
-        // unused positional arguments that occur before the last used argument will not be checked,
-        // but all named arguments and all positional arguments after the last used argument will be checked.
-        args: 'after-used',
+        args: 'all',
 
         // Ignore vars that start with an underscore
         // e.g. if you want to omit a property using object spread:

--- a/packages/eslint-config-sentry/rules/base.js
+++ b/packages/eslint-config-sentry/rules/base.js
@@ -28,7 +28,7 @@ module.exports = {
       'error',
       {
         vars: 'local',
-        args: 'all',
+        args: 'none',
 
         // Ignore vars that start with an underscore
         // e.g. if you want to omit a property using object spread:


### PR DESCRIPTION
Prefix with `_` to ignore

This is no autofixable and is difficult to manually update. Let's move the rule to the strict ruleset for now.