### PR TITLE
Turn on eqeqeq rule

### DIFF
--- a/packages/eslint-config-sentry/rules/base.js
+++ b/packages/eslint-config-sentry/rules/base.js
@@ -132,8 +132,8 @@ module.exports = {
       },
     ],
 
-    // http://eslint.org/docs/rules/eqeqeq [REVISIT ME]
-    eqeqeq: ['off'],
+    // http://eslint.org/docs/rules/eqeqeq
+    eqeqeq: ['error'],
 
     // http://eslint.org/docs/rules/guard-for-in [REVISIT ME]
     'guard-for-in': ['off'],


### PR DESCRIPTION
We don't ever want to rely on type coercion for comparisons. Since this frequently comes up in code review, let's turn on the rule.