### PR TITLE
fix(react): Fix react version settings

### DIFF
--- a/packages/eslint-config-sentry-react/rules/react.js
+++ b/packages/eslint-config-sentry-react/rules/react.js
@@ -7,7 +7,7 @@ module.exports = {
     react: {
       createClass: 'createReactClass', // Regex for Component Factory to use, default to "createReactClass"
       pragma: 'React', // Pragma to use, default to "React"
-      version: 'detect', // React version, default to the latest React stable release
+      version: '16.7.0', // React version, can not `detect` because of getsentry
     },
   },
   rules: {


### PR DESCRIPTION
Cannot use `detect` because of `getsentry`