### PR TITLE
feat(rule): Add rule to restrict importing from `enzyme`

### DIFF
--- a/packages/eslint-config-sentry-app/index.js
+++ b/packages/eslint-config-sentry-app/index.js
@@ -31,6 +31,17 @@ module.exports = {
   settings: {
     'import/resolver': 'webpack',
     'import/extensions': ['.js', '.jsx'],
+    'import/no-restricted-imports': [
+      'error',
+      {
+        paths: [
+          {
+            name: 'enzyme',
+            message: 'Please import from `sentry-test/enzyme` instead. See: ',
+          },
+        ],
+      },
+    ],
   },
 
   rules: {

--- a/packages/eslint-config-sentry-app/index.js
+++ b/packages/eslint-config-sentry-app/index.js
@@ -39,7 +39,8 @@ module.exports = {
         paths: [
           {
             name: 'enzyme',
-            message: 'Please import from `sentry-test/enzyme` instead. See: ',
+            message:
+              'Please import from `sentry-test/enzyme` instead. See: https://github.com/getsentry/frontend-handbook#undefined-theme-properties-in-tests',
           },
         ],
       },

--- a/packages/eslint-config-sentry-app/index.js
+++ b/packages/eslint-config-sentry-app/index.js
@@ -31,7 +31,9 @@ module.exports = {
   settings: {
     'import/resolver': 'webpack',
     'import/extensions': ['.js', '.jsx'],
-    'import/no-restricted-imports': [
+
+    // See: https://eslint.org/docs/rules/no-restricted-imports
+    'no-restricted-imports': [
       'error',
       {
         paths: [

--- a/packages/eslint-config-sentry-app/index.js
+++ b/packages/eslint-config-sentry-app/index.js
@@ -31,8 +31,14 @@ module.exports = {
   settings: {
     'import/resolver': 'webpack',
     'import/extensions': ['.js', '.jsx'],
+  },
 
-    // See: https://eslint.org/docs/rules/no-restricted-imports
+  rules: {
+    /**
+     * Restricted imports, e.g. deprecated libraries, etc
+     *
+     * See: https://eslint.org/docs/rules/no-restricted-imports
+     */
     'no-restricted-imports': [
       'error',
       {
@@ -40,14 +46,12 @@ module.exports = {
           {
             name: 'enzyme',
             message:
-              'Please import from `sentry-test/enzyme` instead. See: https://github.com/getsentry/frontend-handbook#undefined-theme-properties-in-tests',
+              'Please import from `sentry-test/enzyme` instead. See: https://github.com/getsentry/frontend-handbook#undefined-theme-properties-in-tests for more information',
           },
         ],
       },
     ],
-  },
 
-  rules: {
     /**
      * Custom
      */


### PR DESCRIPTION
This will require developers to always import from `sentry-test/enzyme` instead of `enzyme`