### PR TITLE
feat(plugin): Remove `eslint-plugin-getsentry`

### DIFF
--- a/packages/eslint-config-sentry-app/index.js
+++ b/packages/eslint-config-sentry-app/index.js
@@ -26,13 +26,16 @@ module.exports = {
     jquery: true, // hard-loaded into vendor.js
   },
 
-  plugins: ['react', 'import', 'getsentry', 'prettier'],
+  plugins: ['react', 'import', 'prettier'],
 
   settings: {
     'import/resolver': 'webpack',
     'import/extensions': ['.js', '.jsx'],
   },
 
+  /**
+   * Rules
+   */
   rules: {
     /**
      * Restricted imports, e.g. deprecated libraries, etc
@@ -51,12 +54,5 @@ module.exports = {
         ],
       },
     ],
-
-    /**
-     * Custom
-     */
-
-    // highlights literals in JSX components w/o translation tags
-    'getsentry/jsx-needs-il8n': ['off'],
   },
 };

--- a/packages/eslint-config-sentry-app/package.json
+++ b/packages/eslint-config-sentry-app/package.json
@@ -30,7 +30,6 @@
     "eslint-config-sentry": "^1.21.0",
     "eslint-config-sentry-react": "^1.21.0",
     "eslint-import-resolver-webpack": "0.11.1",
-    "eslint-plugin-getsentry": "2.0.0",
     "eslint-plugin-import": "2.18.2",
     "eslint-plugin-jest": "22.17.0",
     "eslint-plugin-prettier": "3.1.1",

--- a/packages/eslint-config-sentry-app/yarn.lock
+++ b/packages/eslint-config-sentry-app/yarn.lock
@@ -387,17 +387,17 @@ eslint-config-prettier@6.3.0:
   dependencies:
     get-stdin "^6.0.0"
 
-eslint-config-sentry-react@^1.19.1:
-  version "1.19.1"
-  resolved "https://registry.yarnpkg.com/eslint-config-sentry-react/-/eslint-config-sentry-react-1.19.1.tgz#b51a3e7ec464645eb31e88f99f78892e5eed9918"
-  integrity sha512-PKpJYeO7wLPLVj4XPC21jQj94AT5eQlLDbzE4+2pfFfveW9v+joOqTVxfM6XZpoSkUO6NSdBSCh2urlOOoLF+g==
+eslint-config-sentry-react@^1.21.0:
+  version "1.21.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-sentry-react/-/eslint-config-sentry-react-1.21.0.tgz#fea2cd57b0339d7a4d3f4179de409f38b31aaf6e"
+  integrity sha512-f6xGBb0XTv/kNmaGNKH01fjtbMBVKAKpiUQtJYtSB46AtAanKDYkfILaBxfo1VyJvrBCarRyWJ21WL+CFH5bkQ==
   dependencies:
-    eslint-config-sentry "^1.19.0"
+    eslint-config-sentry "^1.21.0"
 
-eslint-config-sentry@^1.19.0:
-  version "1.19.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-sentry/-/eslint-config-sentry-1.19.0.tgz#87fcc5a580d826b0e8a1f371fa4ab07b9bd3e587"
-  integrity sha512-cBFsXoFaMSZnxDNVwH3k8Bntr/i2Zh+e5Q0PmEIwn76Mqg5MguG6MzVFEaQ4FYbrBNn5PxDXi9c54SUaDHaL6Q==
+eslint-config-sentry@^1.21.0:
+  version "1.21.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-sentry/-/eslint-config-sentry-1.21.0.tgz#bfd1afc34f1cbf898a93747adcd89ef27f15cf83"
+  integrity sha512-f0+ZN2vpTaQf5o+nrX014vudFus4SXR1Lgog6iiPDnG+nui5VRF6ujRERzkNFBMOIWdSerlpfLts67TuV241pA==
 
 eslint-import-resolver-node@^0.3.2:
   version "0.3.2"
@@ -430,11 +430,6 @@ eslint-module-utils@^2.4.0:
   dependencies:
     debug "^2.6.8"
     pkg-dir "^2.0.0"
-
-eslint-plugin-getsentry@2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-getsentry/-/eslint-plugin-getsentry-2.0.0.tgz#39ce5b2edd8cce28a225f54e63b4292d585682b9"
-  integrity sha1-Oc5bLt2MziiiJfVOY7QpLVhWgrk=
 
 eslint-plugin-import@2.18.2:
   version "2.18.2"


### PR DESCRIPTION
There was only 1 rule that we did not ever use, so removing this dependency