### PR TITLE
feat(rule): Downgrade `react/sort-comp` to a warning instead of error

### DIFF
--- a/packages/eslint-config-sentry-react/rules/react.js
+++ b/packages/eslint-config-sentry-react/rules/react.js
@@ -133,7 +133,7 @@ module.exports = {
     'react/self-closing-comp': ['error'],
 
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/sort-comp.md
-    'react/sort-comp': ['error'],
+    'react/sort-comp': ['warn'],
 
     // Disabled because of prettier
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/wrap-multilines.md


### PR DESCRIPTION
Since this is a warning for `tsx` files because of some typescript compat, we should be consistent and downgrade this to a warning