### PR TITLE
build(actions): Change `lerna publish` to publish from package

### DIFF
--- a/.github/workflows/npmpublish.yml
+++ b/.github/workflows/npmpublish.yml
@@ -17,6 +17,6 @@ jobs:
       - run: yarn install --frozen-lockfile
       - run: yarn lerna bootstrap
       - run: yarn test
-      - run: yarn lerna publish from-git --yes
+      - run: yarn lerna publish from-package --yes
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
This changes GitHub actions to run `lerna publish` using the `from-package` option instead of `from-git`. This means that it will try to publish the version from package.json.