### PR TITLE
feat(rule): Restrict `grid-emotion` in strict ruleset

### DIFF
--- a/packages/eslint-config-sentry-app/strict.js
+++ b/packages/eslint-config-sentry-app/strict.js
@@ -37,5 +37,23 @@ module.exports = {
     'jest/no-large-snapshots': ['error', {maxSize: 2000}],
 
     'sentry/no-styled-shortcut': ['error'],
+
+    'no-restricted-imports': [
+      'error',
+      {
+        paths: [
+          {
+            name: 'enzyme',
+            message:
+              'Please import from `sentry-test/enzyme` instead. See: https://github.com/getsentry/frontend-handbook#undefined-theme-properties-in-tests for more information',
+          },
+          {
+            name: 'grid-emotion',
+            message:
+              '`grid-emotion` is deprecated and is a blocker for upgrading to emotion@10. Please remove usage of `grid-emotion` unless you are editing a Panel component or a component with breakpoints.',
+          },
+        ],
+      },
+    ],
   },
 };

--- a/packages/eslint-config-sentry-app/strict.js
+++ b/packages/eslint-config-sentry-app/strict.js
@@ -1,3 +1,5 @@
+const relaxedRules = require('.');
+
 module.exports = {
   extends: ['sentry-app'],
 
@@ -42,11 +44,7 @@ module.exports = {
       'error',
       {
         paths: [
-          {
-            name: 'enzyme',
-            message:
-              'Please import from `sentry-test/enzyme` instead. See: https://github.com/getsentry/frontend-handbook#undefined-theme-properties-in-tests for more information',
-          },
+          ...relaxedRules.rules['no-restricted-imports'][1].paths,
           {
             name: 'grid-emotion',
             message:


### PR DESCRIPTION
`grid-emotion` is deprecated and is blocking us from upgrading to
emotion@10. Add rule to strict ruleset so that if you touch a file using
it, you should be required to refactor it out.