### PR TITLE
feat(docs): Add link to `grid-emotion` migration guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,27 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.25.0](https://github.com/getsentry/eslint-config-sentry/compare/v1.19.1...v1.25.0) (2019-10-23)
+
+
+### Bug Fixes
+
+* **react:** Fix react version settings ([#31](https://github.com/getsentry/eslint-config-sentry/issues/31)) ([c7936ad](https://github.com/getsentry/eslint-config-sentry/commit/c7936ad))
+
+
+### Features
+
+* **docs:** Add link to `grid-emotion` migration guide ([a21975b](https://github.com/getsentry/eslint-config-sentry/commit/a21975b))
+* **plugin:** Add a plugin for custom rules ([#25](https://github.com/getsentry/eslint-config-sentry/issues/25)) ([52e28f3](https://github.com/getsentry/eslint-config-sentry/commit/52e28f3))
+* **plugin:** Remove `eslint-plugin-getsentry` ([#34](https://github.com/getsentry/eslint-config-sentry/issues/34)) ([6f1a13b](https://github.com/getsentry/eslint-config-sentry/commit/6f1a13b))
+* **rule:** Add rule to restrict importing from `enzyme` ([#32](https://github.com/getsentry/eslint-config-sentry/issues/32)) ([8895154](https://github.com/getsentry/eslint-config-sentry/commit/8895154))
+* **rule:** Downgrade `react/sort-comp` to a warning instead of error ([#36](https://github.com/getsentry/eslint-config-sentry/issues/36)) ([5866d6a](https://github.com/getsentry/eslint-config-sentry/commit/5866d6a))
+* **rule:** Restrict `grid-emotion` in strict ruleset ([#41](https://github.com/getsentry/eslint-config-sentry/issues/41)) ([dfe84ea](https://github.com/getsentry/eslint-config-sentry/commit/dfe84ea))
+
+
+
+
+
 # [1.24.0](https://github.com/getsentry/eslint-config-sentry/compare/v1.19.1...v1.24.0) (2019-10-18)
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,72 +3,34 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [1.25.0](https://github.com/getsentry/eslint-config-sentry/compare/v1.19.1...v1.25.0) (2019-10-23)
-
-
-### Bug Fixes
-
-* **react:** Fix react version settings ([#31](https://github.com/getsentry/eslint-config-sentry/issues/31)) ([c7936ad](https://github.com/getsentry/eslint-config-sentry/commit/c7936ad))
+# [1.25.0](https://github.com/getsentry/eslint-config-sentry/compare/v1.24.0...v1.25.0) (2019-10-23)
 
 
 ### Features
 
 * **docs:** Add link to `grid-emotion` migration guide ([a21975b](https://github.com/getsentry/eslint-config-sentry/commit/a21975b))
-* **plugin:** Add a plugin for custom rules ([#25](https://github.com/getsentry/eslint-config-sentry/issues/25)) ([52e28f3](https://github.com/getsentry/eslint-config-sentry/commit/52e28f3))
-* **plugin:** Remove `eslint-plugin-getsentry` ([#34](https://github.com/getsentry/eslint-config-sentry/issues/34)) ([6f1a13b](https://github.com/getsentry/eslint-config-sentry/commit/6f1a13b))
-* **rule:** Add rule to restrict importing from `enzyme` ([#32](https://github.com/getsentry/eslint-config-sentry/issues/32)) ([8895154](https://github.com/getsentry/eslint-config-sentry/commit/8895154))
-* **rule:** Downgrade `react/sort-comp` to a warning instead of error ([#36](https://github.com/getsentry/eslint-config-sentry/issues/36)) ([5866d6a](https://github.com/getsentry/eslint-config-sentry/commit/5866d6a))
+
+
+
+# [1.24.0](https://github.com/getsentry/eslint-config-sentry/compare/v1.23.0...v1.24.0) (2019-10-18)
+
+
+### Features
+
 * **rule:** Restrict `grid-emotion` in strict ruleset ([#41](https://github.com/getsentry/eslint-config-sentry/issues/41)) ([dfe84ea](https://github.com/getsentry/eslint-config-sentry/commit/dfe84ea))
 
 
 
-
-
-# [1.24.0](https://github.com/getsentry/eslint-config-sentry/compare/v1.19.1...v1.24.0) (2019-10-18)
-
-
-### Bug Fixes
-
-* **react:** Fix react version settings ([#31](https://github.com/getsentry/eslint-config-sentry/issues/31)) ([c7936ad](https://github.com/getsentry/eslint-config-sentry/commit/c7936ad))
+# [1.23.0](https://github.com/getsentry/eslint-config-sentry/compare/v1.22.0...v1.23.0) (2019-10-16)
 
 
 ### Features
 
 * **plugin:** Add a plugin for custom rules ([#25](https://github.com/getsentry/eslint-config-sentry/issues/25)) ([52e28f3](https://github.com/getsentry/eslint-config-sentry/commit/52e28f3))
-* **plugin:** Remove `eslint-plugin-getsentry` ([#34](https://github.com/getsentry/eslint-config-sentry/issues/34)) ([6f1a13b](https://github.com/getsentry/eslint-config-sentry/commit/6f1a13b))
-* **rule:** Add rule to restrict importing from `enzyme` ([#32](https://github.com/getsentry/eslint-config-sentry/issues/32)) ([8895154](https://github.com/getsentry/eslint-config-sentry/commit/8895154))
-* **rule:** Downgrade `react/sort-comp` to a warning instead of error ([#36](https://github.com/getsentry/eslint-config-sentry/issues/36)) ([5866d6a](https://github.com/getsentry/eslint-config-sentry/commit/5866d6a))
-* **rule:** Restrict `grid-emotion` in strict ruleset ([#41](https://github.com/getsentry/eslint-config-sentry/issues/41)) ([dfe84ea](https://github.com/getsentry/eslint-config-sentry/commit/dfe84ea))
 
 
 
-
-
-# [1.23.0](https://github.com/getsentry/eslint-config-sentry/compare/v1.19.1...v1.23.0) (2019-10-16)
-
-
-### Bug Fixes
-
-* **react:** Fix react version settings ([#31](https://github.com/getsentry/eslint-config-sentry/issues/31)) ([c7936ad](https://github.com/getsentry/eslint-config-sentry/commit/c7936ad))
-
-
-### Features
-
-* **plugin:** Add a plugin for custom rules ([#25](https://github.com/getsentry/eslint-config-sentry/issues/25)) ([52e28f3](https://github.com/getsentry/eslint-config-sentry/commit/52e28f3))
-* **plugin:** Remove `eslint-plugin-getsentry` ([#34](https://github.com/getsentry/eslint-config-sentry/issues/34)) ([6f1a13b](https://github.com/getsentry/eslint-config-sentry/commit/6f1a13b))
-* **rule:** Add rule to restrict importing from `enzyme` ([#32](https://github.com/getsentry/eslint-config-sentry/issues/32)) ([8895154](https://github.com/getsentry/eslint-config-sentry/commit/8895154))
-* **rule:** Downgrade `react/sort-comp` to a warning instead of error ([#36](https://github.com/getsentry/eslint-config-sentry/issues/36)) ([5866d6a](https://github.com/getsentry/eslint-config-sentry/commit/5866d6a))
-
-
-
-
-
-# [1.22.0](https://github.com/getsentry/eslint-config-sentry/compare/v1.19.1...v1.22.0) (2019-10-15)
-
-
-### Bug Fixes
-
-* **react:** Fix react version settings ([#31](https://github.com/getsentry/eslint-config-sentry/issues/31)) ([c7936ad](https://github.com/getsentry/eslint-config-sentry/commit/c7936ad))
+# [1.22.0](https://github.com/getsentry/eslint-config-sentry/compare/v1.21.0...v1.22.0) (2019-10-15)
 
 
 ### Features
@@ -76,8 +38,6 @@ See [Conventional Commits](https://conventionalcommits.org) for commit guideline
 * **plugin:** Remove `eslint-plugin-getsentry` ([#34](https://github.com/getsentry/eslint-config-sentry/issues/34)) ([6f1a13b](https://github.com/getsentry/eslint-config-sentry/commit/6f1a13b))
 * **rule:** Add rule to restrict importing from `enzyme` ([#32](https://github.com/getsentry/eslint-config-sentry/issues/32)) ([8895154](https://github.com/getsentry/eslint-config-sentry/commit/8895154))
 * **rule:** Downgrade `react/sort-comp` to a warning instead of error ([#36](https://github.com/getsentry/eslint-config-sentry/issues/36)) ([5866d6a](https://github.com/getsentry/eslint-config-sentry/commit/5866d6a))
-
-
 
 
 

--- a/lerna.json
+++ b/lerna.json
@@ -8,5 +8,5 @@
       "message": "chore(release): Publish %s"
     }
   },
-  "version": "1.24.0"
+  "version": "1.25.0"
 }

--- a/packages/eslint-config-sentry-app/CHANGELOG.md
+++ b/packages/eslint-config-sentry-app/CHANGELOG.md
@@ -3,56 +3,42 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [1.25.0](https://github.com/getsentry/eslint-config-sentry/compare/v1.19.1...v1.25.0) (2019-10-23)
+# [1.25.0](https://github.com/getsentry/eslint-config-sentry/compare/v1.24.0...v1.25.0) (2019-10-23)
 
 
 ### Features
 
 * **docs:** Add link to `grid-emotion` migration guide ([a21975b](https://github.com/getsentry/eslint-config-sentry/commit/a21975b))
-* **plugin:** Add a plugin for custom rules ([#25](https://github.com/getsentry/eslint-config-sentry/issues/25)) ([52e28f3](https://github.com/getsentry/eslint-config-sentry/commit/52e28f3))
-* **plugin:** Remove `eslint-plugin-getsentry` ([#34](https://github.com/getsentry/eslint-config-sentry/issues/34)) ([6f1a13b](https://github.com/getsentry/eslint-config-sentry/commit/6f1a13b))
-* **rule:** Add rule to restrict importing from `enzyme` ([#32](https://github.com/getsentry/eslint-config-sentry/issues/32)) ([8895154](https://github.com/getsentry/eslint-config-sentry/commit/8895154))
+
+# [1.25.0](https://github.com/getsentry/eslint-config-sentry/compare/v1.19.1...v1.25.0) (2019-10-23)
+
+
+# [1.24.0](https://github.com/getsentry/eslint-config-sentry/compare/v1.23.0...v1.24.0) (2019-10-18)
+
+
+### Features
+
 * **rule:** Restrict `grid-emotion` in strict ruleset ([#41](https://github.com/getsentry/eslint-config-sentry/issues/41)) ([dfe84ea](https://github.com/getsentry/eslint-config-sentry/commit/dfe84ea))
 
 
 
 
-
-# [1.24.0](https://github.com/getsentry/eslint-config-sentry/compare/v1.19.1...v1.24.0) (2019-10-18)
-
-
-### Features
-
-* **plugin:** Add a plugin for custom rules ([#25](https://github.com/getsentry/eslint-config-sentry/issues/25)) ([52e28f3](https://github.com/getsentry/eslint-config-sentry/commit/52e28f3))
-* **plugin:** Remove `eslint-plugin-getsentry` ([#34](https://github.com/getsentry/eslint-config-sentry/issues/34)) ([6f1a13b](https://github.com/getsentry/eslint-config-sentry/commit/6f1a13b))
-* **rule:** Add rule to restrict importing from `enzyme` ([#32](https://github.com/getsentry/eslint-config-sentry/issues/32)) ([8895154](https://github.com/getsentry/eslint-config-sentry/commit/8895154))
-* **rule:** Restrict `grid-emotion` in strict ruleset ([#41](https://github.com/getsentry/eslint-config-sentry/issues/41)) ([dfe84ea](https://github.com/getsentry/eslint-config-sentry/commit/dfe84ea))
-
-
-
-
-
-# [1.23.0](https://github.com/getsentry/eslint-config-sentry/compare/v1.19.1...v1.23.0) (2019-10-16)
+# [1.23.0](https://github.com/getsentry/eslint-config-sentry/compare/v1.22.0...v1.23.0) (2019-10-16)
 
 
 ### Features
 
 * **plugin:** Add a plugin for custom rules ([#25](https://github.com/getsentry/eslint-config-sentry/issues/25)) ([52e28f3](https://github.com/getsentry/eslint-config-sentry/commit/52e28f3))
-* **plugin:** Remove `eslint-plugin-getsentry` ([#34](https://github.com/getsentry/eslint-config-sentry/issues/34)) ([6f1a13b](https://github.com/getsentry/eslint-config-sentry/commit/6f1a13b))
-* **rule:** Add rule to restrict importing from `enzyme` ([#32](https://github.com/getsentry/eslint-config-sentry/issues/32)) ([8895154](https://github.com/getsentry/eslint-config-sentry/commit/8895154))
 
 
 
 
-
-# [1.22.0](https://github.com/getsentry/eslint-config-sentry/compare/v1.19.1...v1.22.0) (2019-10-15)
+# [1.22.0](https://github.com/getsentry/eslint-config-sentry/compare/v1.21.0...v1.22.0) (2019-10-15)
 
 
 ### Features
 
 * **plugin:** Remove `eslint-plugin-getsentry` ([#34](https://github.com/getsentry/eslint-config-sentry/issues/34)) ([6f1a13b](https://github.com/getsentry/eslint-config-sentry/commit/6f1a13b))
-* **rule:** Add rule to restrict importing from `enzyme` ([#32](https://github.com/getsentry/eslint-config-sentry/issues/32)) ([8895154](https://github.com/getsentry/eslint-config-sentry/commit/8895154))
-
 
 
 

--- a/packages/eslint-config-sentry-app/CHANGELOG.md
+++ b/packages/eslint-config-sentry-app/CHANGELOG.md
@@ -3,6 +3,21 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.25.0](https://github.com/getsentry/eslint-config-sentry/compare/v1.19.1...v1.25.0) (2019-10-23)
+
+
+### Features
+
+* **docs:** Add link to `grid-emotion` migration guide ([a21975b](https://github.com/getsentry/eslint-config-sentry/commit/a21975b))
+* **plugin:** Add a plugin for custom rules ([#25](https://github.com/getsentry/eslint-config-sentry/issues/25)) ([52e28f3](https://github.com/getsentry/eslint-config-sentry/commit/52e28f3))
+* **plugin:** Remove `eslint-plugin-getsentry` ([#34](https://github.com/getsentry/eslint-config-sentry/issues/34)) ([6f1a13b](https://github.com/getsentry/eslint-config-sentry/commit/6f1a13b))
+* **rule:** Add rule to restrict importing from `enzyme` ([#32](https://github.com/getsentry/eslint-config-sentry/issues/32)) ([8895154](https://github.com/getsentry/eslint-config-sentry/commit/8895154))
+* **rule:** Restrict `grid-emotion` in strict ruleset ([#41](https://github.com/getsentry/eslint-config-sentry/issues/41)) ([dfe84ea](https://github.com/getsentry/eslint-config-sentry/commit/dfe84ea))
+
+
+
+
+
 # [1.24.0](https://github.com/getsentry/eslint-config-sentry/compare/v1.19.1...v1.24.0) (2019-10-18)
 
 

--- a/packages/eslint-config-sentry-app/package.json
+++ b/packages/eslint-config-sentry-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-sentry-app",
-  "version": "1.24.0",
+  "version": "1.25.0",
   "description": "sentry.io eslint config",
   "main": "index.js",
   "scripts": {},
@@ -25,14 +25,14 @@
   "homepage": "https://github.com/getsentry/eslint-config-sentry#readme",
   "dependencies": {
     "eslint-config-prettier": "6.3.0",
-    "eslint-config-sentry": "^1.24.0",
-    "eslint-config-sentry-react": "^1.24.0",
+    "eslint-config-sentry": "^1.25.0",
+    "eslint-config-sentry-react": "^1.25.0",
     "eslint-import-resolver-webpack": "0.11.1",
     "eslint-plugin-import": "2.18.2",
     "eslint-plugin-jest": "22.17.0",
     "eslint-plugin-prettier": "3.1.1",
     "eslint-plugin-react": "7.15.1",
-    "eslint-plugin-sentry": "^1.24.0"
+    "eslint-plugin-sentry": "^1.25.0"
   },
   "volta": {
     "node": "8.10.0",

--- a/packages/eslint-config-sentry-app/strict.js
+++ b/packages/eslint-config-sentry-app/strict.js
@@ -48,7 +48,7 @@ module.exports = {
           {
             name: 'grid-emotion',
             message:
-              '`grid-emotion` is deprecated and is a blocker for upgrading to emotion@10. Please remove usage of `grid-emotion` unless you are editing a Panel component or a component with breakpoints.',
+              '`grid-emotion` is deprecated and is a blocker for upgrading to emotion@10. Please remove usage of `grid-emotion` unless you are editing a Panel component or a component with breakpoints. See https://github.com/getsentry/frontend-handbook/blob/master/migration-guides/grid-emotion.md for migration help.',
           },
         ],
       },

--- a/packages/eslint-config-sentry-react/CHANGELOG.md
+++ b/packages/eslint-config-sentry-react/CHANGELOG.md
@@ -3,6 +3,23 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.25.0](https://github.com/getsentry/eslint-config-sentry/compare/v1.19.1...v1.25.0) (2019-10-23)
+
+
+### Bug Fixes
+
+* **react:** Fix react version settings ([#31](https://github.com/getsentry/eslint-config-sentry/issues/31)) ([c7936ad](https://github.com/getsentry/eslint-config-sentry/commit/c7936ad))
+
+
+### Features
+
+* **plugin:** Add a plugin for custom rules ([#25](https://github.com/getsentry/eslint-config-sentry/issues/25)) ([52e28f3](https://github.com/getsentry/eslint-config-sentry/commit/52e28f3))
+* **rule:** Downgrade `react/sort-comp` to a warning instead of error ([#36](https://github.com/getsentry/eslint-config-sentry/issues/36)) ([5866d6a](https://github.com/getsentry/eslint-config-sentry/commit/5866d6a))
+
+
+
+
+
 # [1.24.0](https://github.com/getsentry/eslint-config-sentry/compare/v1.19.1...v1.24.0) (2019-10-18)
 
 

--- a/packages/eslint-config-sentry-react/package.json
+++ b/packages/eslint-config-sentry-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-sentry-react",
-  "version": "1.24.0",
+  "version": "1.25.0",
   "description": "sentry.io eslint config",
   "main": "index.js",
   "scripts": {},
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/getsentry/eslint-config-sentry#readme",
   "dependencies": {
-    "eslint-config-sentry": "^1.24.0"
+    "eslint-config-sentry": "^1.25.0"
   },
   "volta": {
     "node": "8.10.0",

--- a/packages/eslint-config-sentry/CHANGELOG.md
+++ b/packages/eslint-config-sentry/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.25.0](https://github.com/getsentry/eslint-config-sentry/compare/v1.19.1...v1.25.0) (2019-10-23)
+
+
+### Features
+
+* **plugin:** Add a plugin for custom rules ([#25](https://github.com/getsentry/eslint-config-sentry/issues/25)) ([52e28f3](https://github.com/getsentry/eslint-config-sentry/commit/52e28f3))
+
+
+
+
+
 # [1.24.0](https://github.com/getsentry/eslint-config-sentry/compare/v1.19.1...v1.24.0) (2019-10-18)
 
 

--- a/packages/eslint-config-sentry/package.json
+++ b/packages/eslint-config-sentry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-sentry",
-  "version": "1.24.0",
+  "version": "1.25.0",
   "description": "sentry.io eslint config",
   "main": "index.js",
   "scripts": {},

--- a/packages/eslint-plugin-sentry/CHANGELOG.md
+++ b/packages/eslint-plugin-sentry/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.25.0](https://github.com/getsentry/eslint-config-sentry/compare/v1.19.1...v1.25.0) (2019-10-23)
+
+
+### Features
+
+* **plugin:** Add a plugin for custom rules ([#25](https://github.com/getsentry/eslint-config-sentry/issues/25)) ([52e28f3](https://github.com/getsentry/eslint-config-sentry/commit/52e28f3))
+
+
+
+
+
 # [1.24.0](https://github.com/getsentry/eslint-config-sentry/compare/v1.19.1...v1.24.0) (2019-10-18)
 
 

--- a/packages/eslint-plugin-sentry/package.json
+++ b/packages/eslint-plugin-sentry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-sentry",
-  "version": "1.24.0",
+  "version": "1.25.0",
   "description": "sentry.io eslint plugin",
   "keywords": [
     "eslint",


### PR DESCRIPTION
To help people migrate from `grid-emotion`