### PR TITLE
feat(rule): Restrict import of `marked`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.26.0](https://github.com/getsentry/eslint-config-sentry/compare/v1.25.0...v1.26.0) (2019-11-05)
+
+### Features
+
+* **rule:** Restrict import of `marked` ([f337b14](https://github.com/getsentry/eslint-config-sentry/commit/f337b14))
+
+
 # [1.25.0](https://github.com/getsentry/eslint-config-sentry/compare/v1.24.0...v1.25.0) (2019-10-23)
 
 

--- a/lerna.json
+++ b/lerna.json
@@ -8,5 +8,5 @@
       "message": "chore(release): Publish %s"
     }
   },
-  "version": "1.25.0"
+  "version": "1.26.0"
 }

--- a/packages/eslint-config-sentry-app/CHANGELOG.md
+++ b/packages/eslint-config-sentry-app/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.26.0](https://github.com/getsentry/eslint-config-sentry/compare/v1.25.0...v1.26.0) (2019-11-05)
+
+
+### Features
+
+* **rule:** Restrict import of `marked` ([f337b14](https://github.com/getsentry/eslint-config-sentry/commit/f337b14))
+
+
+
+
+
 # [1.25.0](https://github.com/getsentry/eslint-config-sentry/compare/v1.24.0...v1.25.0) (2019-10-23)
 
 

--- a/packages/eslint-config-sentry-app/index.js
+++ b/packages/eslint-config-sentry-app/index.js
@@ -51,6 +51,12 @@ module.exports = {
             message:
               'Please import from `sentry-test/enzyme` instead. See: https://github.com/getsentry/frontend-handbook#undefined-theme-properties-in-tests for more information',
           },
+
+          {
+            name: 'marked',
+            message:
+              "Please import marked from 'app/utils/marked' so that we can ensure sanitation of marked output.",
+          },
         ],
       },
     ],

--- a/packages/eslint-config-sentry-app/package.json
+++ b/packages/eslint-config-sentry-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-sentry-app",
-  "version": "1.25.0",
+  "version": "1.26.0",
   "description": "sentry.io eslint config",
   "main": "index.js",
   "scripts": {},
@@ -25,14 +25,14 @@
   "homepage": "https://github.com/getsentry/eslint-config-sentry#readme",
   "dependencies": {
     "eslint-config-prettier": "6.3.0",
-    "eslint-config-sentry": "^1.25.0",
-    "eslint-config-sentry-react": "^1.25.0",
+    "eslint-config-sentry": "^1.26.0",
+    "eslint-config-sentry-react": "^1.26.0",
     "eslint-import-resolver-webpack": "0.11.1",
     "eslint-plugin-import": "2.18.2",
     "eslint-plugin-jest": "22.17.0",
     "eslint-plugin-prettier": "3.1.1",
     "eslint-plugin-react": "7.15.1",
-    "eslint-plugin-sentry": "^1.25.0"
+    "eslint-plugin-sentry": "^1.26.0"
   },
   "volta": {
     "node": "8.10.0",

--- a/packages/eslint-config-sentry-react/CHANGELOG.md
+++ b/packages/eslint-config-sentry-react/CHANGELOG.md
@@ -3,63 +3,18 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
-# [1.25.0](https://github.com/getsentry/eslint-config-sentry/compare/v1.19.1...v1.25.0) (2019-10-23)
-
-
-### Bug Fixes
-
-* **react:** Fix react version settings ([#31](https://github.com/getsentry/eslint-config-sentry/issues/31)) ([c7936ad](https://github.com/getsentry/eslint-config-sentry/commit/c7936ad))
+# [1.23.0](https://github.com/getsentry/eslint-config-sentry/compare/v1.22.0...v1.23.0) (2019-10-16)
 
 
 ### Features
 
 * **plugin:** Add a plugin for custom rules ([#25](https://github.com/getsentry/eslint-config-sentry/issues/25)) ([52e28f3](https://github.com/getsentry/eslint-config-sentry/commit/52e28f3))
-* **rule:** Downgrade `react/sort-comp` to a warning instead of error ([#36](https://github.com/getsentry/eslint-config-sentry/issues/36)) ([5866d6a](https://github.com/getsentry/eslint-config-sentry/commit/5866d6a))
 
 
 
 
 
-# [1.24.0](https://github.com/getsentry/eslint-config-sentry/compare/v1.19.1...v1.24.0) (2019-10-18)
-
-
-### Bug Fixes
-
-* **react:** Fix react version settings ([#31](https://github.com/getsentry/eslint-config-sentry/issues/31)) ([c7936ad](https://github.com/getsentry/eslint-config-sentry/commit/c7936ad))
-
-
-### Features
-
-* **plugin:** Add a plugin for custom rules ([#25](https://github.com/getsentry/eslint-config-sentry/issues/25)) ([52e28f3](https://github.com/getsentry/eslint-config-sentry/commit/52e28f3))
-* **rule:** Downgrade `react/sort-comp` to a warning instead of error ([#36](https://github.com/getsentry/eslint-config-sentry/issues/36)) ([5866d6a](https://github.com/getsentry/eslint-config-sentry/commit/5866d6a))
-
-
-
-
-
-# [1.23.0](https://github.com/getsentry/eslint-config-sentry/compare/v1.19.1...v1.23.0) (2019-10-16)
-
-
-### Bug Fixes
-
-* **react:** Fix react version settings ([#31](https://github.com/getsentry/eslint-config-sentry/issues/31)) ([c7936ad](https://github.com/getsentry/eslint-config-sentry/commit/c7936ad))
-
-
-### Features
-
-* **plugin:** Add a plugin for custom rules ([#25](https://github.com/getsentry/eslint-config-sentry/issues/25)) ([52e28f3](https://github.com/getsentry/eslint-config-sentry/commit/52e28f3))
-* **rule:** Downgrade `react/sort-comp` to a warning instead of error ([#36](https://github.com/getsentry/eslint-config-sentry/issues/36)) ([5866d6a](https://github.com/getsentry/eslint-config-sentry/commit/5866d6a))
-
-
-
-
-
-# [1.22.0](https://github.com/getsentry/eslint-config-sentry/compare/v1.19.1...v1.22.0) (2019-10-15)
-
-
-### Bug Fixes
-
-* **react:** Fix react version settings ([#31](https://github.com/getsentry/eslint-config-sentry/issues/31)) ([c7936ad](https://github.com/getsentry/eslint-config-sentry/commit/c7936ad))
+# [1.22.0](https://github.com/getsentry/eslint-config-sentry/compare/v1.21.0...v1.22.0) (2019-10-15)
 
 
 ### Features

--- a/packages/eslint-config-sentry-react/package.json
+++ b/packages/eslint-config-sentry-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-sentry-react",
-  "version": "1.25.0",
+  "version": "1.26.0",
   "description": "sentry.io eslint config",
   "main": "index.js",
   "scripts": {},
@@ -26,7 +26,7 @@
   },
   "homepage": "https://github.com/getsentry/eslint-config-sentry#readme",
   "dependencies": {
-    "eslint-config-sentry": "^1.25.0"
+    "eslint-config-sentry": "^1.26.0"
   },
   "volta": {
     "node": "8.10.0",

--- a/packages/eslint-config-sentry/package.json
+++ b/packages/eslint-config-sentry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-sentry",
-  "version": "1.25.0",
+  "version": "1.26.0",
   "description": "sentry.io eslint config",
   "main": "index.js",
   "scripts": {},

--- a/packages/eslint-plugin-sentry/package.json
+++ b/packages/eslint-plugin-sentry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-sentry",
-  "version": "1.25.0",
+  "version": "1.26.0",
   "description": "sentry.io eslint plugin",
   "keywords": [
     "eslint",


### PR DESCRIPTION
Direct imports of `marked` are restricted so that we can ensure sanitation
of `marked` output (i.e. for XSS)