### PR TITLE
feat(rule): Forbid importing directly from main  module

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.27.0](https://github.com/getsentry/eslint-config-sentry/compare/v1.26.0...v1.27.0) (2019-11-12)
+
+
+### Features
+
+* **rule:** Forbid importing directly from main  module ([4160fef](https://github.com/getsentry/eslint-config-sentry/commit/4160fef))
+
+
+
+
+
 # [1.26.0](https://github.com/getsentry/eslint-config-sentry/compare/v1.25.0...v1.26.0) (2019-11-05)
 
 ### Features

--- a/lerna.json
+++ b/lerna.json
@@ -8,5 +8,5 @@
       "message": "chore(release): Publish %s"
     }
   },
-  "version": "1.26.0"
+  "version": "1.27.0"
 }

--- a/packages/eslint-config-sentry-app/CHANGELOG.md
+++ b/packages/eslint-config-sentry-app/CHANGELOG.md
@@ -3,6 +3,17 @@
 All notable changes to this project will be documented in this file.
 See [Conventional Commits](https://conventionalcommits.org) for commit guidelines.
 
+# [1.27.0](https://github.com/getsentry/eslint-config-sentry/compare/v1.26.0...v1.27.0) (2019-11-12)
+
+
+### Features
+
+* **rule:** Forbid importing directly from main  module ([4160fef](https://github.com/getsentry/eslint-config-sentry/commit/4160fef))
+
+
+
+
+
 # [1.26.0](https://github.com/getsentry/eslint-config-sentry/compare/v1.25.0...v1.26.0) (2019-11-05)
 
 

--- a/packages/eslint-config-sentry-app/index.js
+++ b/packages/eslint-config-sentry-app/index.js
@@ -57,6 +57,12 @@ module.exports = {
             message:
               "Please import marked from 'app/utils/marked' so that we can ensure sanitation of marked output.",
           },
+
+          {
+            name: 'lodash',
+            message:
+              "Please import lodash utilities individually. e.g. `import isEqual from 'lodash/isEqual';`. See https://github.com/getsentry/frontend-handbook#lodash from for information",
+          },
         ],
       },
     ],

--- a/packages/eslint-config-sentry-app/package.json
+++ b/packages/eslint-config-sentry-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-sentry-app",
-  "version": "1.26.0",
+  "version": "1.27.0",
   "description": "sentry.io eslint config",
   "main": "index.js",
   "scripts": {},


### PR DESCRIPTION
Instead, import the specific module. e.g. `import isEqual from 'lodash/isEqual'`