### PR TITLE
feat(rule): Update `grid-emotion` rule to new library: `reflexbox`

### DIFF
--- a/packages/eslint-config-sentry-app/strict.js
+++ b/packages/eslint-config-sentry-app/strict.js
@@ -46,9 +46,9 @@ module.exports = {
         paths: [
           ...relaxedRules.rules['no-restricted-imports'][1].paths,
           {
-            name: 'grid-emotion',
+            name: 'reflexbox',
             message:
-              '`grid-emotion` is deprecated and is a blocker for upgrading to emotion@10. Please remove usage of `grid-emotion` unless you are editing a Panel component or a component with breakpoints. See https://github.com/getsentry/frontend-handbook/blob/master/migration-guides/grid-emotion.md for migration help.',
+              '`reflexbox` (previously `grid-emotion`) is deprecated. Please remove usage of `reflexbox` unless you are editing a Panel component or a component with breakpoints. See https://github.com/getsentry/frontend-handbook/blob/master/migration-guides/grid-emotion.md for migration help.',
           },
         ],
       },


### PR DESCRIPTION
`grid-emotion` has been deprecated for quite awhile, and reflexbox is the updated and maintained version of it.

We updated the library while upgrading `emotion` here: https://github.com/getsentry/sentry/pull/15106