### PR TITLE
feat(rule): Group `sentry`, `getsentry`, and `admin` separately

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -3,6 +3,7 @@
   "packages": [
     "packages/*"
   ],
+  "npmClient": "yarn",
   "command": {
     "version": {
       "message": "chore(release): Publish %s"

--- a/packages/eslint-config-sentry-app/index.js
+++ b/packages/eslint-config-sentry-app/index.js
@@ -105,6 +105,17 @@ module.exports = {
           {
             pattern: 'sentry*/**',
             group: 'internal',
+            position: 'before',
+          },
+          {
+            pattern: 'getsentry*/**',
+            group: 'internal',
+            position: 'after',
+          },
+          {
+            pattern: 'admin*/**',
+            group: 'internal',
+            position: 'after',
           },
         ],
         pathGroupsExcludedImportTypes: ['builtin'],


### PR DESCRIPTION
This will group imports starting with these prefixes in separate groups