### PR TITLE
feat(rule): Dynamic imports require `webpackChunkName`

### DIFF
--- a/packages/eslint-config-sentry-react/rules/imports.js
+++ b/packages/eslint-config-sentry-react/rules/imports.js
@@ -110,6 +110,11 @@ module.exports = {
     // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-dynamic-require.md
     'import/no-dynamic-require': ['off'],
 
+    "import/dynamic-import-chunkname": [2, {
+      importFunctions: ["dynamicImport"],
+      webpackChunknameFormat: "[a-zA-Z0-57-9-/_]+"
+    }],
+
     // prevent importing the submodules of other modules
     // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-internal-modules.md
     'import/no-internal-modules': [


### PR DESCRIPTION
This makes it required that any dynamic import must be prefixed with `webpackChunkName`. See https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/dynamic-import-chunkname.md