### PR TITLE
feat(rule): Add rule restricting usage of @sentry/browser

### DIFF
--- a/packages/eslint-config-sentry-app/index.js
+++ b/packages/eslint-config-sentry-app/index.js
@@ -95,6 +95,12 @@ module.exports = {
           },
 
           {
+            name: '@sentry/browser',
+            message:
+              'Please import from `@sentry/react` to ensure consistency throughout the codebase.',
+          },
+
+          {
             name: 'marked',
             message:
               "Please import marked from 'app/utils/marked' so that we can ensure sanitation of marked output.",


### PR DESCRIPTION
We should now only be using `@sentry/react`.