### PR TITLE
feat(rule): Add plugin to disallow use of `toMatchSnapshot()`

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -30,7 +30,7 @@ jobs:
         run: |
           cd sentry
           yarn install
-          yarn add ../packages/eslint-config-sentry-app
+          yarn add -D ../packages/eslint-config-sentry-app
 
       - name: Run lint in sentry
         run: |

--- a/lerna.json
+++ b/lerna.json
@@ -13,5 +13,5 @@
       "yes": true
     }
   },
-  "version": "1.43.0"
+  "version": "1.44.0-alpha.0"
 }

--- a/packages/eslint-config-sentry-app/index.js
+++ b/packages/eslint-config-sentry-app/index.js
@@ -155,6 +155,8 @@ module.exports = {
     'sentry/no-react-hooks': ['error'],
 
     'sentry/no-digits-in-tn': ['error'],
+
+    'sentry/no-to-match-snapshot': ['error'],
   },
 
   overrides: [

--- a/packages/eslint-config-sentry-app/package.json
+++ b/packages/eslint-config-sentry-app/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-sentry-app",
-  "version": "1.43.0",
+  "version": "1.44.0-alpha.0",
   "description": "sentry.io eslint config",
   "main": "index.js",
   "scripts": {},
@@ -28,7 +28,7 @@
     "@typescript-eslint/parser": "^3.5.0",
     "eslint-config-prettier": "6.3.0",
     "eslint-config-sentry": "^1.43.0",
-    "eslint-config-sentry-react": "^1.43.0",
+    "eslint-config-sentry-react": "^1.44.0-alpha.0",
     "eslint-import-resolver-typescript": "^2.0.0",
     "eslint-import-resolver-webpack": "^0.12.2",
     "eslint-plugin-emotion": "^10.0.27",
@@ -36,7 +36,7 @@
     "eslint-plugin-jest": "22.17.0",
     "eslint-plugin-prettier": "3.1.1",
     "eslint-plugin-react": "7.15.1",
-    "eslint-plugin-sentry": "^1.43.0"
+    "eslint-plugin-sentry": "^1.44.0-alpha.0"
   },
   "volta": {
     "node": "10.16.3",

--- a/packages/eslint-config-sentry-app/yarn.lock
+++ b/packages/eslint-config-sentry-app/yarn.lock
@@ -497,17 +497,17 @@ eslint-config-prettier@6.3.0:
   dependencies:
     get-stdin "^6.0.0"
 
-eslint-config-sentry-react@^1.40.0:
-  version "1.41.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-sentry-react/-/eslint-config-sentry-react-1.41.0.tgz#481438c921a4f86399fc0756f6219009a0124c3b"
-  integrity sha512-StW0hOL/E9UawXDVhidPqCMsd4J7IIuHk3kBwR/dxHKxKmNiMXOgIhRapL0bGWG/1TweGJgW/Flp8YnGnRhp3g==
+eslint-config-sentry-react@^1.43.0:
+  version "1.43.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-sentry-react/-/eslint-config-sentry-react-1.43.0.tgz#2b89d727076d89699a7be72adf2c0256bd03021f"
+  integrity sha512-1TiupDlaWqIFt7fbH1NRUz1rlAB04e6CLj0aIdLdrzXo1hbhSQbjrRZI4w5TfmKkGtGlD5qwRTu4F6mmzbt3Bg==
   dependencies:
-    eslint-config-sentry "^1.41.0"
+    eslint-config-sentry "^1.43.0"
 
-eslint-config-sentry@^1.40.0, eslint-config-sentry@^1.41.0:
-  version "1.41.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-sentry/-/eslint-config-sentry-1.41.0.tgz#46c6967ce73bc85674a9f6044d8268253139f3c7"
-  integrity sha512-xwFUmMSXzSz9+xIdN03kZwanEspVhvSQZiFyXz8sv5xrawwwPUukvjOKqnZ6gZKMX4QuUb/Y8rqowljIdRbm+w==
+eslint-config-sentry@^1.43.0:
+  version "1.43.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-sentry/-/eslint-config-sentry-1.43.0.tgz#c751e62773edc5527afd7a05a38708c4a2d244da"
+  integrity sha512-Id9Q1o6XFii9WkNgH1yRUZJeBhV23peG2887fy3aB9klHbNUkiQx1LAZloeeU4sgaGOpCH5HRLBEC8fECG1L5Q==
 
 eslint-import-resolver-node@^0.3.3:
   version "0.3.4"
@@ -605,10 +605,10 @@ eslint-plugin-react@7.15.1:
     prop-types "^15.7.2"
     resolve "^1.12.0"
 
-eslint-plugin-sentry@^1.40.0:
-  version "1.41.0"
-  resolved "https://registry.yarnpkg.com/eslint-plugin-sentry/-/eslint-plugin-sentry-1.41.0.tgz#e1864423284116b2c036b7cbc3e6e184be72c361"
-  integrity sha512-wBbPGf4GPSnDewm7wa78pSLJp2rBmtC/qnR7fPoYcJzmYCvrUqzonP0uFBjHu8bMwu8hLl6OpFrE+DiPNeTTzw==
+eslint-plugin-sentry@^1.43.0:
+  version "1.43.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-sentry/-/eslint-plugin-sentry-1.43.0.tgz#114e248e63260054ad68ae5178f41122a4c5e77c"
+  integrity sha512-ick0N35r7nwHuv/cDGkB0PTmygE6xFjnAL531s39ykukHxDHeP7jTPya0vrRmYTlCzrgcZFCJXqxLaqp0alSyA==
   dependencies:
     requireindex "~1.1.0"
 

--- a/packages/eslint-config-sentry-react/package.json
+++ b/packages/eslint-config-sentry-react/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-sentry-react",
-  "version": "1.43.0",
+  "version": "1.44.0-alpha.0",
   "description": "sentry.io eslint config",
   "main": "index.js",
   "scripts": {},

--- a/packages/eslint-config-sentry-react/yarn.lock
+++ b/packages/eslint-config-sentry-react/yarn.lock
@@ -2,7 +2,7 @@
 # yarn lockfile v1
 
 
-eslint-config-sentry@^1.40.0:
-  version "1.41.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-sentry/-/eslint-config-sentry-1.41.0.tgz#46c6967ce73bc85674a9f6044d8268253139f3c7"
-  integrity sha512-xwFUmMSXzSz9+xIdN03kZwanEspVhvSQZiFyXz8sv5xrawwwPUukvjOKqnZ6gZKMX4QuUb/Y8rqowljIdRbm+w==
+eslint-config-sentry@^1.43.0:
+  version "1.43.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-sentry/-/eslint-config-sentry-1.43.0.tgz#c751e62773edc5527afd7a05a38708c4a2d244da"
+  integrity sha512-Id9Q1o6XFii9WkNgH1yRUZJeBhV23peG2887fy3aB9klHbNUkiQx1LAZloeeU4sgaGOpCH5HRLBEC8fECG1L5Q==

--- a/packages/eslint-plugin-sentry/docs/rules/no-to-match-snapshot.md
+++ b/packages/eslint-plugin-sentry/docs/rules/no-to-match-snapshot.md
@@ -1,0 +1,35 @@
+# disallow jest `toMatchSnapshot` (no-to-match-snapshot)
+
+We find jest snapshots to be noisy and not very helpful in most cases. Instead we have a `toSnapshot` matcher that serializes the component in HTML and during CI, renders the HTML in a browser and captures it as an image. This way it is easier to see how CSS changes can affect your components.
+
+
+## Rule Details
+
+This rule prevents the usage of jest's `toMatchSnapshot()` and prefers our custom `toSnapshot()` where possible. 
+
+Examples of **correct** code for this rule:
+
+```js
+it('snapshots', function() {
+  const wrapper = mount(<MyComponent />);
+  expect(wrapper).toSnapshot(); // This will do nothing locally
+});
+```
+
+Examples of **incorrect** code for this rule:
+
+```js
+it('snapshots', function() {
+  const wrapper = mount(<MyComponent />);
+  expect(wrapper).toMatchSnapshot();
+});
+```
+
+## When Not To Use It
+
+If you want to be able to use jest snapshots
+
+## Further Reading
+
+* https://github.com/getsentry/sentry/pull/19878
+* https://github.com/getsentry/action-visual-snapshot/

--- a/packages/eslint-plugin-sentry/lib/rules/no-to-match-snapshot.js
+++ b/packages/eslint-plugin-sentry/lib/rules/no-to-match-snapshot.js
@@ -1,0 +1,46 @@
+/**
+ * @fileoverview Disallow use of `toMatchSnapshot()`
+ * @author Billy Vong
+ */
+'use strict';
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+module.exports = {
+  meta: {
+    docs: {
+      description: 'disallow use of `toMatchSnapshot()`',
+      category: 'Best Practices',
+      recommended: true,
+    },
+    fixable: true,
+    schema: [],
+  },
+  create: function(context) {
+    //----------------------------------------------------------------------
+    // Public
+    //----------------------------------------------------------------------
+
+
+    return {
+      Identifier(node) {
+        if (node.name !== 'toMatchSnapshot') {
+          return;
+        }
+
+        context.report({
+          node,
+          message: "Do not use jest snapshots, instead use `toSnapshot()` for visual snapshots",
+
+          fix(fixer) {
+            return [
+              fixer.replaceText(node, 'toSnapshot')
+            ];
+          }
+        });
+      },
+    };
+  },
+};

--- a/packages/eslint-plugin-sentry/package.json
+++ b/packages/eslint-plugin-sentry/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-plugin-sentry",
-  "version": "1.43.0",
+  "version": "1.44.0-alpha.0",
   "description": "sentry.io eslint plugin",
   "keywords": [
     "eslint",

--- a/packages/eslint-plugin-sentry/tests/lib/rules/no-to-match-snapshot.js
+++ b/packages/eslint-plugin-sentry/tests/lib/rules/no-to-match-snapshot.js
@@ -1,0 +1,46 @@
+/**
+ * @fileoverview Disallow use of `toMatchSnapshot()`
+ * @author Billy Vong
+ */
+'use strict';
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var rule = require('../../../lib/rules/no-to-match-snapshot'),
+  path = require('path'),
+  RuleTester = require('eslint').RuleTester;
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+RuleTester.setDefaultConfig({
+  parserOptions: {
+    ecmaVersion: 6,
+    sourceType: 'module'
+  }
+});
+var ruleTester = new RuleTester();
+
+ruleTester.run('no-to-match-snapshot', rule, {
+  valid: [
+    // give me some code that won't trigger a warning
+    {
+      code: "expect(wrapper).toHaveLength(1)",
+    },
+  ],
+
+  invalid: [
+    {
+      code: "expect(wrapper).toMatchSnapshot()",
+      errors: [
+        {
+          message: "Do not use jest snapshots, instead use `toSnapshot()` for visual snapshots",
+          type: 'Identifier',
+        },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
This disallows use of `toMatchSnapshot()`, opting for visual snapshots instead. This is `fixable`.