### PR TITLE
feat(rule): Change import sort groups for `(get)sentry-images`

### DIFF
--- a/packages/eslint-config-sentry-app/index.js
+++ b/packages/eslint-config-sentry-app/index.js
@@ -144,7 +144,11 @@ module.exports = {
           ['^(sentry-test)(/.*|$)'],
 
           // Internal packages.
-          ['^(app|sentry|sentry-locale)(/.*|$)'],
+          ['^(sentry-locale|sentry-images)(/.*|$)'],
+
+          ['^(getsentry-images)(/.*|$)'],
+
+          ['^(app|sentry)(/.*|$)'],
 
           // Getsentry packages.
           ['^(admin|getsentry)(/.*|$)'],


### PR DESCRIPTION
This makes `sentry-locale` and `sentry-images` a separate group from `sentry` (`app`), as well as `getsentry-images` being its own group.