### PR TITLE
feat: Relax the JSX transform rules.

### DIFF
--- a/packages/eslint-config-sentry-react/rules/react.js
+++ b/packages/eslint-config-sentry-react/rules/react.js
@@ -44,8 +44,9 @@ module.exports = {
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-no-duplicate-props.md
     'react/jsx-no-duplicate-props': ['error'],
 
+    // Disabled as we use the newer JSX transform babel plugin.
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-uses-react.md
-    'react/jsx-uses-react': ['error'],
+    'react/jsx-uses-react': ['off'],
 
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/jsx-uses-vars.md
     'react/jsx-uses-vars': ['error'],
@@ -122,8 +123,9 @@ module.exports = {
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/require-render-return.md
     'react/require-render-return': ['error'],
 
+    // Disabled as we are using the newer JSX transform babel plugin.
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/react-in-jsx-scope.md
-    'react/react-in-jsx-scope': ['error'],
+    'react/react-in-jsx-scope': ['off'],
 
     // https://github.com/yannickcr/eslint-plugin-react/blob/master/docs/rules/self-closing-comp.md
     'react/self-closing-comp': ['error'],


### PR DESCRIPTION
We'll be switching to the new JSX transform for getsentry/sentry and these rules are no longer required.

Breakout from getsentry/sentry#25796