### PR TITLE
feat(rule): Disable requiring `webpackChunkName`

### DIFF
--- a/packages/eslint-config-sentry-react/rules/imports.js
+++ b/packages/eslint-config-sentry-react/rules/imports.js
@@ -110,10 +110,8 @@ module.exports = {
     // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-dynamic-require.md
     'import/no-dynamic-require': ['off'],
 
-    "import/dynamic-import-chunkname": [2, {
-      importFunctions: ["dynamicImport"],
-      webpackChunknameFormat: "[a-zA-Z0-57-9-/_]+"
-    }],
+    // Use webpack default chunk names
+    "import/dynamic-import-chunkname": ['off'],
 
     // prevent importing the submodules of other modules
     // https://github.com/benmosher/eslint-plugin-import/blob/master/docs/rules/no-internal-modules.md


### PR DESCRIPTION
Prefer webpack defaults for chunk names, instead of requiring the developer to generate one.