### PR TITLE
ref(rules): Restrict sentry-test/enzyme

### DIFF
--- a/packages/eslint-config-sentry-app/index.js
+++ b/packages/eslint-config-sentry-app/index.js
@@ -151,22 +151,6 @@ module.exports = {
     ],
 
     /**
-     * Warnings for imports still in use but will be removed
-     */
-    'no-restricted-imports': [
-      'warn',
-      {
-        paths: [
-          {
-            name: 'sentry-test/enzyme',
-            message:
-              'As we are converting our enzyme tests to React Testing Library, please avoid using `sentry-test/enzyme` and use `sentry-test/reactTestingLibrary` instead.',
-          },
-        ],
-      },
-    ],
-
-    /**
      * Better import sorting
      */
     'sort-imports': 'off',

--- a/packages/eslint-config-sentry-app/strict.js
+++ b/packages/eslint-config-sentry-app/strict.js
@@ -34,6 +34,15 @@ module.exports = {
           },
         ],
       },
+      {
+        paths: [
+          {
+            name: 'sentry-test/enzyme',
+            message:
+              '`sentry-test/enzyme` is deprecated, so unless you are updating a file that uses enzyme, please write tests using `sentry-test/reactTestingLibrary`.',
+          },
+        ],
+      },
     ],
   },
 


### PR DESCRIPTION
As we are migrating our enzyme tests to the React Test Library, we would like to warn devs that we recommend using `sentry-test/reactTestingLibrary` over `sentry-test/enzyme`