### PR TITLE
ref(custom-rule): Remove testing-library/prefer-screen-queries rule

### DIFF
--- a/packages/eslint-config-sentry-react/index.js
+++ b/packages/eslint-config-sentry-react/index.js
@@ -18,7 +18,6 @@ module.exports = {
     // highlights literals in JSX components w/o translation tags
     'getsentry/jsx-needs-il8n': ['off'],
     'testing-library/render-result-naming-convention': 'off',
-    'testing-library/prefer-screen-queries': 'off',
   },
 
   /**


### PR DESCRIPTION
As soon as we merge the PR https://github.com/getsentry/sentry/pull/29948 I believe this rule can be turned on