### PR TITLE
ref(rules): Restrict direct color imports from theme.tsx

### DIFF
--- a/packages/eslint-config-sentry-app/index.js
+++ b/packages/eslint-config-sentry-app/index.js
@@ -146,6 +146,12 @@ module.exports = {
             message:
               'Avoid usage of any react-bootstrap components as it will soon be removed',
           },
+          {
+            name: 'sentry/utils/theme',
+            importNames: ['lightColors', 'darkColors'],
+            message:
+              "'lightColors' and 'darkColors' exports intended for use in Storybook only. Instead, use theme prop from emotion or the useTheme hook.",
+          },
         ],
       },
     ],


### PR DESCRIPTION
The color objects (lightColors and darkColors) are exported for use in Storybook only. We should restrict importing them elsewhere.