### PR TITLE
ref: Fix curly rule due to prettier override

### DIFF
--- a/packages/eslint-config-sentry-app/index.js
+++ b/packages/eslint-config-sentry-app/index.js
@@ -72,6 +72,9 @@ module.exports = {
     // support tsc errors so....
     'no-undef': 'off',
 
+    // Override prettier's configuration of this rule
+    curly: ['error'],
+
     /**
      * Need to use typescript version of these rules
      */


### PR DESCRIPTION
Prettier was overriding this rule, as discovered here https://github.com/getsentry/sentry/pull/30878#discussion_r778209923