### PR TITLE
ref(no-restricted-imports): Add explicit @testing-library names

### DIFF
--- a/packages/eslint-config-sentry-app/index.js
+++ b/packages/eslint-config-sentry-app/index.js
@@ -122,7 +122,17 @@ module.exports = {
               'Please import from `sentry-test/enzyme` instead. See: https://github.com/getsentry/frontend-handbook#undefined-theme-properties-in-tests for more information',
           },
           {
-            name: '@testing-library',
+            name: "@testing-library/react",
+            message:
+              'Please import from `sentry-test/reactTestingLibrary` instead so that we can ensure consistency throughout the codebase',
+          },
+          {
+            name: "@testing-library/react-hooks",
+            message:
+              'Please import from `sentry-test/reactTestingLibrary` instead so that we can ensure consistency throughout the codebase',
+          },
+          {
+            name: "@testing-library/user-event",
             message:
               'Please import from `sentry-test/reactTestingLibrary` instead so that we can ensure consistency throughout the codebase',
           },
@@ -131,7 +141,6 @@ module.exports = {
             message:
               'Please import from `@sentry/react` to ensure consistency throughout the codebase.',
           },
-
           {
             name: 'marked',
             message:


### PR DESCRIPTION
Adding all @testing-library dependencies separated, since `@testing-library/*` or `@testing-library `don't seem to work 

requires https://github.com/getsentry/sentry/pull/31925