### PR TITLE
feat: Do not allow ANY anonymous default exports

### DIFF
--- a/packages/eslint-config-sentry-react/rules/imports.js
+++ b/packages/eslint-config-sentry-react/rules/imports.js
@@ -144,16 +144,6 @@ module.exports = {
 
     // Reports if a module"s default export is unnamed
     // https://github.com/benmosher/eslint-plugin-import/blob/d9b712ac7fd1fddc391f7b234827925c160d956f/docs/rules/no-anonymous-default-export.md
-    'import/no-anonymous-default-export': [
-      'error',
-      {
-        allowArray: true,
-        allowArrowFunction: false,
-        allowAnonymousClass: false,
-        allowAnonymousFunction: false,
-        allowLiteral: true,
-        allowObject: true,
-      },
-    ],
+    'import/no-anonymous-default-export': ['error'],
   },
 };


### PR DESCRIPTION
In the land of language servers where auto-importing uses the named default exports as hints, we should probably never allow anonymous default exports.