### PR TITLE
fix: Remove invalid no-restricted-imports syntax

### DIFF
--- a/packages/eslint-config-sentry-app/strict.js
+++ b/packages/eslint-config-sentry-app/strict.js
@@ -25,15 +25,9 @@ module.exports = {
     'no-restricted-imports': [
       'error',
       {
-        paths: [...relaxedRules.rules['no-restricted-imports'][1].paths],
-      },
-      {
         paths: [
-          {
-            name: 'sentry-test/enzyme',
-            message:
-              '`sentry-test/enzyme` is deprecated, so unless you are updating a file that uses enzyme, please write tests using `sentry-test/reactTestingLibrary`.',
-          },
+          ...relaxedRules.rules['no-restricted-imports'][1].paths,
+          // Additional Strict import restrictions go here
         ],
       },
     ],


### PR DESCRIPTION
The sentry-test/enzyme rule never seems to have actually been applied. It was originally added in [0] but turns it the syntax wasn't right (it's actually not simple to have both warnings and errors for a single no-restricted-imports rule, see [1]).

This just removes it, thus fixing the configuration syntax.

[0]: https://github.com/getsentry/eslint-config-sentry/pull/113
[1]: https://github.com/eslint/eslint/issues/14061