### PR TITLE
fix: Actually diasslow all unnamed default exports

### DIFF
--- a/packages/eslint-config-sentry-react/rules/imports.js
+++ b/packages/eslint-config-sentry-react/rules/imports.js
@@ -144,6 +144,17 @@ module.exports = {
 
     // Reports if a module"s default export is unnamed
     // https://github.com/benmosher/eslint-plugin-import/blob/d9b712ac7fd1fddc391f7b234827925c160d956f/docs/rules/no-anonymous-default-export.md
-    'import/no-anonymous-default-export': ['error'],
+    'import/no-anonymous-default-export': [
+      'error',
+      {
+        allowArray: false,
+        allowArrowFunction: false,
+        allowAnonymousClass: false,
+        allowAnonymousFunction: false,
+        allowCallExpression: false,
+        allowLiteral: false,
+        allowObject: false,
+      },
+    ],
   },
 };


### PR DESCRIPTION
https://github.com/import-js/eslint-plugin-import/blob/main/docs/rules/no-anonymous-default-export.md

turns out that the default is actually

```tsx
"import/no-anonymous-default-export": ["error", {
  "allowArray": false,
  "allowArrowFunction": false,
  "allowAnonymousClass": false,
  "allowAnonymousFunction": false,
  "allowCallExpression": true, // The true value here is for backward compatibility
  "allowLiteral": false,
  "allowObject": false
}]
```

`allowCallExpression` was allowing `export default styled()`...`;` through