### PR TITLE
feat(eslint-react): add hook rules

### DIFF
--- a/packages/eslint-config-sentry-react/index.js
+++ b/packages/eslint-config-sentry-react/index.js
@@ -7,6 +7,7 @@ module.exports = {
     'plugin:jest/recommended',
     'sentry-react/rules/jest',
     'plugin:jest-dom/recommended',
+    'plugin:react-hooks/recommended',
   ],
 
   plugins: ['jest-dom', 'testing-library', 'typescript-sort-keys'],

--- a/packages/eslint-config-sentry-react/package.json
+++ b/packages/eslint-config-sentry-react/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "eslint-config-sentry": "^1.92.0",
     "eslint-plugin-jest-dom": "^4.0.1",
+    "eslint-plugin-react-hooks": "^4.4.0",
     "eslint-plugin-testing-library": "^5.0.3",
     "eslint-plugin-typescript-sort-keys": "^2.1.0"
   },

--- a/packages/eslint-config-sentry-react/yarn.lock
+++ b/packages/eslint-config-sentry-react/yarn.lock
@@ -234,10 +234,10 @@ escape-string-regexp@^1.0.5:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz#1b61c0562190a8dff6ae3bb2cf0200ca130b86d4"
   integrity sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
 
-eslint-config-sentry@^1.76.0:
-  version "1.76.0"
-  resolved "https://registry.yarnpkg.com/eslint-config-sentry/-/eslint-config-sentry-1.76.0.tgz#3ed18e277686dbb085c602c6d285fb583c24cfa7"
-  integrity sha512-6RNp6duS8NTwLhMS6uOKJSTzC3F7Re38x7D5mNHSTj7R1QFjL4iMHec86Ph64S7ogT7YRKfYW+1S0kOYWImMgw==
+eslint-config-sentry@^1.92.0:
+  version "1.92.0"
+  resolved "https://registry.yarnpkg.com/eslint-config-sentry/-/eslint-config-sentry-1.92.0.tgz#04637d25e9b52679dbbeb74970f9eef1b481cff4"
+  integrity sha512-jLMMw2RnMIxyNngN2IYjjJBsOlnTt2LxeHIX4NreNXA+TDnOzz8qE8FFxyYPiUJrJAS9CGOXlbl9viVEYb9KDg==
 
 eslint-plugin-jest-dom@^4.0.1:
   version "4.0.1"
@@ -247,6 +247,11 @@ eslint-plugin-jest-dom@^4.0.1:
     "@babel/runtime" "^7.16.3"
     "@testing-library/dom" "^8.11.1"
     requireindex "^1.2.0"
+
+eslint-plugin-react-hooks@^4.4.0:
+  version "4.4.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.4.0.tgz#71c39e528764c848d8253e1aa2c7024ed505f6c4"
+  integrity sha512-U3RVIfdzJaeKDQKEJbz5p3NW8/L80PCATJAfuojwbaEL+gBjfGdhUcGde+WGUW46Q5sr/NgxevsIiDtNXrvZaQ==
 
 eslint-plugin-testing-library@^5.0.3:
   version "5.0.4"


### PR DESCRIPTION
By default, this is set to warn on missing dependencies and error on hook rules. I'll add the plugin manually and test on getsentry/sentry to prepare for this PR in case it would break master.

https://reactjs.org/docs/hooks-rules.html is a good read to understand what the plugin does, but also how hooks are meant to be called and why they cannot be conditionally called (https://reactjs.org/docs/hooks-rules.html#explanation).

