### PR TITLE
feat: Add import restriction on overflowEllipsis

### DIFF
--- a/packages/eslint-config-sentry-app/index.js
+++ b/packages/eslint-config-sentry-app/index.js
@@ -168,6 +168,11 @@ module.exports = {
             message:
               "'lightColors' and 'darkColors' exports intended for use in Storybook only. Instead, use theme prop from emotion or the useTheme hook.",
           },
+          {
+            name: 'sentry/styles/overflowEllipsis',
+            message:
+              "'overflowEllipsis' has been moved to the theme object. To use it, call ${p => p.theme.overflowEllipsis} inside any styled component template literal.",
+          },
         ],
       },
     ],


### PR DESCRIPTION
Restrict imports of `overflowEllipsis` since in https://github.com/getsentry/sentry/pull/33924 we're moving it to the theme object.

Requires https://github.com/getsentry/sentry/pull/33924.