### PR TITLE
feat: Add require-await rule

### DIFF
--- a/packages/eslint-config-sentry/rules/base.js
+++ b/packages/eslint-config-sentry/rules/base.js
@@ -268,6 +268,9 @@ module.exports = {
     // https://eslint.org/docs/rules/no-else-return
     'no-else-return': ['error', {allowElseIf: false}],
 
+    // https://eslint.org/docs/rules/require-await
+    'require-await': ['error'],
+
     // https://eslint.org/docs/rules/spaced-comment
     'spaced-comment': [
       'error',


### PR DESCRIPTION
Disallows a function to be `async` unless it has an `await` inside the body