### PR TITLE
feat(rules): Prevent imports of the withRouter HOC

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -16,7 +16,6 @@ jobs:
         with:
           repository: getsentry/sentry
           path: sentry
-          ref: disable-eslint-rule-withRouter
 
       - uses: actions/setup-node@v2
         with:


### PR DESCRIPTION
## Objective:
Prevent new components from using the withRouter HOC. withRouter is deprecated in react-router v6, which is our upgrade target.