### PR TITLE
feat: Ban `String` `Number` `Object` as types

### DIFF
--- a/packages/eslint-config-sentry-app/index.js
+++ b/packages/eslint-config-sentry-app/index.js
@@ -169,7 +169,7 @@ module.exports = {
               "'lightColors' and 'darkColors' exports intended for use in Storybook only. Instead, use theme prop from emotion or the useTheme hook.",
           },
           {
-            name: "react-router",
+            name: 'react-router',
             importNames: ['withRouter'],
             message:
               "Use 'useLocation', 'useParams', 'useNavigate', 'useRoutes' from sentry/utils instead.",
@@ -224,6 +224,51 @@ module.exports = {
     'sentry/no-digits-in-tn': ['error'],
 
     'sentry/no-to-match-snapshot': ['error'],
+
+    // Based on https://github.com/xojs/eslint-config-xo-typescript/blob/2a7e3b0b3c28b0c25866721298e67947a95767ab/index.js#L123
+    '@typescript-eslint/ban-types': [
+      'error',
+      {
+        extendDefaults: false,
+        types: {
+          String: {
+            message: 'Use `string` instead.',
+            fixWith: 'string',
+          },
+          Number: {
+            message: 'Use `number` instead.',
+            fixWith: 'number',
+          },
+          Boolean: {
+            message: 'Use `boolean` instead.',
+            fixWith: 'boolean',
+          },
+          Symbol: {
+            message: 'Use `symbol` instead.',
+            fixWith: 'symbol',
+          },
+          BigInt: {
+            message: 'Use `bigint` instead.',
+            fixWith: 'bigint',
+          },
+          Object: {
+            message:
+              'The `Object` type is mostly the same as `unknown`. You probably want `Record<string, unknown>` instead. See https://github.com/typescript-eslint/typescript-eslint/pull/848',
+            fixWith: 'Record<string, unknown>',
+          },
+          // TODO(scttcper): Turn these on to make our types more strict
+          // object: {
+          // 	message: 'The `object` type is hard to use. Use `Record<string, unknown>` instead. See: https://github.com/typescript-eslint/typescript-eslint/pull/848',
+          // 	fixWith: 'Record<string, unknown>'
+          // },
+          // Function: 'Use a specific function type instead, like `() => void`.',
+          '[]': "Don't use the empty array type `[]`. It only allows empty arrays. Use `SomeType[]` instead.",
+          '[[]]':
+            "Don't use `[[]]`. It only allows an array with a single element which is an empty array. Use `SomeType[][]` instead.",
+          '[[[]]]': "Don't use `[[[]]]`. Use `SomeType[][][]` instead.",
+        },
+      },
+    ],
   },
 
   overrides: [


### PR DESCRIPTION
> Don’t ever use the types Number, String, Boolean, Symbol, or Object These types refer to non-primitive boxed objects that are almost never used appropriately in JavaScript code.

https://www.typescriptlang.org/docs/handbook/declaration-files/do-s-and-don-ts.html
