### PR TITLE
Add new `t-only-literal` rule for translations

### DIFF
--- a/packages/eslint-plugin-sentry/lib/rules/t-only-literal.js
+++ b/packages/eslint-plugin-sentry/lib/rules/t-only-literal.js
@@ -1,0 +1,82 @@
+/**
+ * @fileoverview Rule to disallow using anything but strings in `t`, `tn`, and `tct`
+ * @author Evan Purkhiser
+ */
+'use strict';
+
+//------------------------------------------------------------------------------
+// Rule Definition
+//------------------------------------------------------------------------------
+
+const TRANSLATION_FNS = ['t', 'tn', 'tct'];
+
+module.exports = {
+  meta: {
+    docs: {
+      description: 'disallow using non string literals in t(), tn(), and tct()',
+      category: 'Best Practices',
+      recommended: true,
+    },
+    schema: [],
+  },
+  create: function (context) {
+    // variables should be defined here
+
+    //----------------------------------------------------------------------
+    // Helpers
+    //----------------------------------------------------------------------
+
+    // any helper functions should go here or else delete this section
+
+    //----------------------------------------------------------------------
+    // Public
+    //----------------------------------------------------------------------
+
+    return {
+      CallExpression(node) {
+        if (!TRANSLATION_FNS.includes(node.callee.name)) {
+          return;
+        }
+
+        if (node.arguments.length === 0) {
+          return;
+        }
+
+        function checkTranslationArg(arg) {
+          // Template literals should not be used
+          if (arg.type === 'TemplateLiteral') {
+            // Nothing to do if there are no expressions. That's fine
+            if (arg.expressions.length === 0) {
+              return;
+            }
+
+            context.report({
+              node: arg,
+              message:
+                'Dynamic value interpolation cannot be used in translation functions. Use a parameterized string literal instead.',
+            });
+
+            return;
+          }
+
+          // Anything that's not a string is no good
+          if (arg.type !== 'Literal') {
+            context.report({
+              node: arg,
+              message: `${node.callee.name}() cannot be used to translate dynamic values. Use a parameterized string literal instead.`,
+            });
+
+            return;
+          }
+        }
+
+        checkTranslationArg(node.arguments[0]);
+
+        // We need to check both args for `tn`
+        if (node.callee.name === 'tn' && node.arguments.length > 1) {
+          checkTranslationArg(node.arguments[1]);
+        }
+      },
+    };
+  },
+};

--- a/packages/eslint-plugin-sentry/tests/lib/rules/t-only-literal.js
+++ b/packages/eslint-plugin-sentry/tests/lib/rules/t-only-literal.js
@@ -1,0 +1,82 @@
+/**
+ * @fileoverview disallow using %d within tn()
+ * @author matej minar
+ */
+'use strict';
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+var rule = require('../../../lib/rules/t-only-literal'),
+  path = require('path'),
+  RuleTester = require('eslint').RuleTester;
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+RuleTester.setDefaultConfig({
+  parserOptions: {
+    ecmaVersion: 6,
+  },
+});
+var ruleTester = new RuleTester();
+
+ruleTester.run('t-only-literal', rule, {
+  valid: [
+    {code: "t('This is fine')"},
+    {code: 't(`This is fine`)'},
+    {code: "t('This is %s', status)"},
+    {code: "tn('%s project', '%s projects', 5)"},
+    {code: "tct('This is [status]', {status})"},
+  ],
+
+  invalid: [
+    {
+      code: 't(`Your project name is ${project.name}!`)',
+      errors: [
+        {
+          message: `Dynamic value interpolation cannot be used in translation functions. Use a parameterized string literal instead.`,
+          type: 'TemplateLiteral',
+        },
+      ],
+    },
+    {
+      code: 'tn(`thing %s`, `thing ${two} %s`, value)',
+      errors: [
+        {
+          message: `Dynamic value interpolation cannot be used in translation functions. Use a parameterized string literal instead.`,
+          type: 'TemplateLiteral',
+        },
+      ],
+    },
+    {
+      code: 't(someStringVariable)',
+      errors: [
+        {
+          message: `t() cannot be used to translate dynamic values. Use a parameterized string literal instead.`,
+          type: 'Identifier',
+        },
+      ],
+    },
+    {
+      code: "t('string ' + variable + ' string')",
+      errors: [
+        {
+          message: `t() cannot be used to translate dynamic values. Use a parameterized string literal instead.`,
+          type: 'BinaryExpression',
+        },
+      ],
+    },
+    {
+      code: 'tct(someStringVariable, {project: key})',
+      errors: [
+        {
+          message: `tct() cannot be used to translate dynamic values. Use a parameterized string literal instead.`,
+          type: 'Identifier',
+        },
+      ],
+    },
+  ],
+});


### PR DESCRIPTION
This should help us to no longer produce translation calls on the
frontend that can't actually be translated since they're dynamic.

See here where I fixed a bunch https://github.com/getsentry/sentry/pull/40304

I started trying to make it fixable. But there's a good number of cases
to account for to make that work, so I gave up haha.

<img width="928" alt="image" src="https://user-images.githubusercontent.com/1421724/196927624-37d23d08-b451-48fe-92ef-e78dec7a9567.png">
