### PR TITLE
feat: Add rule to discourage use of withSentryRouter

### DIFF
--- a/packages/eslint-config-sentry-app/index.js
+++ b/packages/eslint-config-sentry-app/index.js
@@ -174,6 +174,12 @@ module.exports = {
             message:
               "Use 'useLocation', 'useParams', 'useNavigate', 'useRoutes' from sentry/utils instead.",
           },
+          {
+            name: 'sentry/utils/withSentryRouter',
+            importNames: ['withSentryRouter'],
+            message:
+              "Use 'useLocation', 'useParams', 'useNavigate', 'useRoutes' from sentry/utils instead.",
+          },
         ],
       },
     ],


### PR DESCRIPTION
I'm adding the `withSentryRouter` higher-order component in https://github.com/getsentry/sentry/pull/41797, which is a wrapper of `withRouter` from the `react-router` library. I aim to replace any and all instances of `withRouter` that wrap class components with `withSentryRouter` in both `sentry` and `getsentry`.

Since we discourage the use of `withRouter` in new React components, we should also discourage the use of `withSentryRouter` in new React components as well.