### PR TITLE
feat: Add rule to disallow lookbehinds in regexp

### DIFF
--- a/packages/eslint-config-sentry-app/index.js
+++ b/packages/eslint-config-sentry-app/index.js
@@ -37,6 +37,7 @@ module.exports = {
     'react',
     'sentry',
     'simple-import-sort',
+    'no-lookahead-lookbehind-regexp',
   ],
 
   settings: {
@@ -276,6 +277,14 @@ module.exports = {
           '[[[]]]': "Don't use `[[[]]]`. Use `SomeType[][][]` instead.",
         },
       },
+    ],
+
+    // Don't allow lookbehind expressions in regexp as they crash safari
+    // We've accidentally used lookbehinds a few times and caused problems.
+    'no-lookahead-lookbehind-regexp/no-lookahead-lookbehind-regexp':  [
+      'error',
+      'no-lookbehind',
+      'no-negative-lookbehind',
     ],
   },
 

--- a/packages/eslint-config-sentry-app/package.json
+++ b/packages/eslint-config-sentry-app/package.json
@@ -34,6 +34,7 @@
     "eslint-import-resolver-webpack": "^0.13.2",
     "eslint-plugin-import": "^2.27.5",
     "eslint-plugin-jest": "^27.2.1",
+    "eslint-plugin-no-lookahead-lookbehind-regexp": "0.1.0",
     "eslint-plugin-prettier": "^4.2.1",
     "eslint-plugin-react": "^7.32.2",
     "eslint-plugin-sentry": "^1.110.0",


### PR DESCRIPTION
Safari prior to last week does not support lookbehinds of any kind in regexp patterns and crashes should it encounter one. We've forgotten about this limitation several times and catching it with lint should help prevent future problems.