### PR TITLE
feat: Disable typescript version mismatch warning

### DIFF
--- a/packages/eslint-config-sentry-app/index.js
+++ b/packages/eslint-config-sentry-app/index.js
@@ -13,6 +13,7 @@ module.exports = {
   parser: '@typescript-eslint/parser',
 
   parserOptions: {
+    warnOnUnsupportedTypeScriptVersion: false,
     ecmaVersion: 6,
     sourceType: 'module',
     ecmaFeatures: {


### PR DESCRIPTION
disables the warning when typescript is not within the explicit version. **usually** there is not issues with using a newer version

docs - https://typescript-eslint.io/architecture/parser/#configuration

other popular libraries that disable this check https://github.com/xojs/eslint-config-xo-typescript/blob/631c7b8a8885737dad8ea34d21610fcb0331baf0/index.js#LL80C3-L80C45