### PR TITLE
Add multiline-comment-style rule

### DIFF
--- a/packages/eslint-config-sentry/rules/base.js
+++ b/packages/eslint-config-sentry/rules/base.js
@@ -271,6 +271,9 @@ module.exports = {
     // https://eslint.org/docs/rules/require-await
     'require-await': ['error'],
 
+    // https://eslint.org/docs/rules/multiline-comment-style
+    'multiline-comment-style': ['error', 'separate-lines'],
+
     // https://eslint.org/docs/rules/spaced-comment
     'spaced-comment': [
       'error',


### PR DESCRIPTION
Enforce comments to use this style

```
// This is a comment
// that spans across multiple lines
```

You CAN NOT use:

```
/*
 * This type of comment
 */
```

You CAN still use:

```
/**
 * This is a jsdoc style comment. Text here will appear in the language
 * server help text hover
 */
```