### PR TITLE
fix: Add v3 to prettier peer dependency, remove v1

### DIFF
--- a/packages/eslint-config-sentry-app/package.json
+++ b/packages/eslint-config-sentry-app/package.json
@@ -20,7 +20,7 @@
   },
   "peerDependencies": {
     "eslint": ">=8",
-    "prettier": "1.x || 2.x"
+    "prettier": "2.x || 3.x"
   },
   "homepage": "https://github.com/getsentry/eslint-config-sentry#readme",
   "dependencies": {

--- a/packages/eslint-config-sentry-docs/package.json
+++ b/packages/eslint-config-sentry-docs/package.json
@@ -20,7 +20,7 @@
   },
   "peerDependencies": {
     "eslint": ">=8",
-    "prettier": "1.x || 2.x"
+    "prettier": "2.x || 3.x"
   },
   "homepage": "https://github.com/getsentry/eslint-config-sentry#readme",
   "dependencies": {


### PR DESCRIPTION
silences this warning

```
eslint-config-sentry-app#prettier@1.x || 2.x" doesn't satisfy found match of "prettier@3.0.3
```