### PR TITLE
feat: allow double equal checks

### DIFF
--- a/packages/eslint-config-sentry/rules/base.js
+++ b/packages/eslint-config-sentry/rules/base.js
@@ -134,7 +134,7 @@ module.exports = {
     ],
 
     // https://eslint.org/docs/rules/eqeqeq
-    eqeqeq: ['error'],
+    eqeqeq: 'off',
 
     // https://eslint.org/docs/rules/guard-for-in [REVISIT ME]
     'guard-for-in': ['off'],
@@ -149,7 +149,7 @@ module.exports = {
     'no-else-return': ['off'],
 
     // https://eslint.org/docs/rules/no-eq-null
-    'no-eq-null': ['error'],
+    'no-eq-null': 'off',
 
     // https://eslint.org/docs/rules/no-eval
     'no-eval': ['error'],


### PR DESCRIPTION
Double equal is used to simplify `value === undefined && value === null`. We shouldn't disallow them.

Ref: https://github.com/getsentry/sentry/pull/61593