### PR TITLE
fix: add missing react-hooks plugin

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,8 +1,6 @@
 {
   "lerna": "2.1.2",
-  "packages": [
-    "packages/*"
-  ],
+  "packages": ["packages/*"],
   "npmClient": "yarn",
   "command": {
     "version": {

--- a/packages/eslint-config-sentry-react/index.js
+++ b/packages/eslint-config-sentry-react/index.js
@@ -9,7 +9,7 @@ module.exports = {
     'plugin:jest-dom/recommended',
   ],
 
-  plugins: ['jest-dom', 'testing-library', 'typescript-sort-keys'],
+  plugins: ['jest-dom', 'testing-library', 'typescript-sort-keys', 'react-hooks'],
 
   rules: {
     /**


### PR DESCRIPTION
Adds missing `react-hooks` plugin to enable support for `react-hooks/exhaustive-deps` rule