### PR TITLE
feat: Remove webpack resolver

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -20,7 +20,7 @@
     "indentStyle": "space",
     "indentWidth": 2,
     "lineWidth": 90,
-    "ignore": []
+    "ignore": ["*/package.json", "lerna.json"]
   },
   "javascript": {
     "formatter": {

--- a/packages/eslint-config-sentry-app/index.js
+++ b/packages/eslint-config-sentry-app/index.js
@@ -38,7 +38,6 @@ module.exports = {
     },
     'import/resolver': {
       typescript: {},
-      webpack: {},
     },
     'import/extensions': ['.js', '.jsx'],
   },

--- a/packages/eslint-config-sentry-app/package.json
+++ b/packages/eslint-config-sentry-app/package.json
@@ -29,7 +29,6 @@
     "eslint-config-sentry": "^2.6.0",
     "eslint-config-sentry-react": "^2.6.0",
     "eslint-import-resolver-typescript": "^3.6.1",
-    "eslint-import-resolver-webpack": "^0.13.8",
     "eslint-plugin-import": "^2.29.1",
     "eslint-plugin-jest": "^28.2.0",
     "eslint-plugin-no-lookahead-lookbehind-regexp": "0.1.0",

--- a/packages/eslint-config-sentry-docs/index.js
+++ b/packages/eslint-config-sentry-docs/index.js
@@ -36,7 +36,6 @@ module.exports = {
     },
     'import/resolver': {
       typescript: {},
-      webpack: {},
     },
     'import/extensions': ['.js', '.jsx'],
   },

--- a/packages/eslint-config-sentry-docs/package.json
+++ b/packages/eslint-config-sentry-docs/package.json
@@ -29,7 +29,6 @@
     "eslint-config-sentry": "^2.6.0",
     "eslint-config-sentry-react": "^2.6.0",
     "eslint-import-resolver-typescript": "^3.6.1",
-    "eslint-import-resolver-webpack": "^0.13.8",
     "eslint-plugin-import": "^2.29.1",
     "eslint-plugin-jest": "^27.6.3",
     "eslint-plugin-no-lookahead-lookbehind-regexp": "0.3.0",


### PR DESCRIPTION
We no longer need webpack to resolve things, typescript resolver should be used in 99% of places. This is causing getsentry to hang currently